### PR TITLE
Resolve "Error: Cannot find module 'fs-extra'"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node run.js"
   },
   "dependencies": {
+    "fs-extra": "^9.0.0",
     "puppeteer": "^2.1.1"
   }
 }


### PR DESCRIPTION
This PR adds `fs-extra` to `package.json`.

**What happened**

After I cloned https://github.com/cape-io/airtable-schema.git and ran `npm i`, I ran `npm start`.  It produced the following output:

```
internal/modules/cjs/loader.js:955
  throw err;
  ^

Error: Cannot find module 'fs-extra'
Require stack:
- /cape-io/airtable-schema/index.js
- /cape-io/airtable-schema/run.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:952:15)
    at Function.Module._load (internal/modules/cjs/loader.js:835:27)
    at Module.require (internal/modules/cjs/loader.js:1012:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/cape-io/airtable-schema/index.js:2:23)
    at Module._compile (internal/modules/cjs/loader.js:1123:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1143:10)
    at Module.load (internal/modules/cjs/loader.js:972:32)
    at Function.Module._load (internal/modules/cjs/loader.js:872:14)
    at Module.require (internal/modules/cjs/loader.js:1012:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/cape-io/airtable-schema/index.js',
    '/cape-io/airtable-schema/run.js'
  ]
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! airtable@1.0.0 start: `node run.js`
npm ERR! Exit status 1
```

I then ran `npm install fs-extra` and `npm start` again, and it worked without errors.

This PR implements the `npm install fs-extra` step in `package.json`.

I'm on a MacBook Air running macOS Mojave version 10.14.6.